### PR TITLE
Tests: Replaces now unresolvable USER_CERTIFICATES_DIR

### DIFF
--- a/app/src/androidTest/java/com.nutomic.zertman.test/CertificateManagerTest.java
+++ b/app/src/androidTest/java/com.nutomic.zertman.test/CertificateManagerTest.java
@@ -181,7 +181,7 @@ public class CertificateManagerTest extends AndroidTestCase {
 			}
 			assertNotNull(Shell.SU.run(
 					"mv " + source.getAbsolutePath() + " " +
-							CertificateManager.USER_CERTIFICATES_DIR + "/" + TEST_CERTIFICATE_NAME));
+							CertificateManager.getUserCertificatesDir() + "/" + TEST_CERTIFICATE_NAME));
 			// NOTE: We use CertificateManager.moveCertificateToSystem() to avoid
 			// implementing system remount again.
 			return (isSystemCertificate)


### PR DESCRIPTION
This pull request corrects an erroneous test that results in a build error:
The change introduced by commit 11e4cc882b9bf4a15f4f68a7ec313ade9e708f81	(Implemented CertificateManager (including tests).) had not been propagated in CertificateManagerTest, as shown in pull request.